### PR TITLE
chore: fix redundant casts warning in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ disallow_incomplete_defs = True
 check_untyped_defs = True
 warn_unused_ignores = True
 warn_unused_configs = True
-warn_redundant_casts = 
+warn_redundant_casts = True
 
 
 [pylint]


### PR DESCRIPTION
chore: fix redundant casts warning in setup.cfg